### PR TITLE
fix: suppress cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,10 @@
-project(foxglove_msgs)
-
 find_package(ros_environment REQUIRED)
 
 set(ROS_VERSION $ENV{ROS_VERSION})
 
 if(${ROS_VERSION} EQUAL 1)
-
   cmake_minimum_required(VERSION 2.8.3)
+  project(foxglove_msgs)
 
   # Default to C++11
   if(NOT CMAKE_CXX_STANDARD)
@@ -30,8 +28,8 @@ if(${ROS_VERSION} EQUAL 1)
   catkin_package(CATKIN_DEPENDS message_runtime)
 
 elseif(${ROS_VERSION} EQUAL 2)
-
   cmake_minimum_required(VERSION 3.5)
+  project(foxglove_msgs)
 
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
suppress cmake warning https://build.ros.org/job/Ndev__foxglove_msgs__ubuntu_focal_amd64/2/


<!-- link relevant GitHub issues -->
